### PR TITLE
Pydantic Model Mapping with Field Alias Support and Extensive Test Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,81 @@ mapper.add_mapping(source=Source, target=Target)
 mapper.map(source, target)  # Updates existing target instance
 ```
 
+#### Pydantic Models Mapping
+
+Map between Pydantic models and other object types:
+
+```python
+from pydantic import BaseModel
+
+class UserModel(BaseModel):
+    name: str
+    email: str
+    age: int
+
+class UserDTO:
+    def __init__(self, name: str, email: str, age: int):
+        self.name = name
+        self.email = email
+        self.age = age
+
+mapper = Mapper()
+mapper.add_mapping(source=UserModel, target=UserDTO)
+
+user_model = UserModel(name="John", email="john@example.com", age=30)
+user_dto = mapper.map(user_model, UserDTO)
+```
+
+POM automatically handles Pydantic model attributes during mapping. You can also apply transformations:
+
+```python
+mapper.add_mapping(
+    source=UserModel,
+    target=UserDTO,
+    mapping={"name": lambda n: n.upper()}
+)
+```
+
+##### ⚠️ Mapping Pydantic Models with Aliases
+
+When working with Pydantic's models as targets, pay attention to its aliases. POM does not discover the correct mapping automatically, which may result in attributes being skipped or incorrectly mapped. For example, if a Pydantic model uses aliases like `firstName` for `first_name`, POM will not map these attributes unless explicitly specified. To correctly map the object in this scenario, you should provide the aliases as names in the `mapping` dict to the `add_mapping` method.
+
+Providing the right aliases as mapping:
+
+```python
+from pydantic import BaseModel, Field
+
+class UserDTO:
+    def __init__(self, first_name: str, last_name: str, email_address: str):
+        self.first_name = first_name
+        self.last_name = last_name
+        self.email_address = email_address
+
+class UserModel(BaseModel):
+    first_name: str = Field(alias="firstName")
+    last_name: str = Field(alias="lastName")
+    email_address: str = Field(alias="emailAddress")
+
+
+mapper = Mapper()
+mapper.add_mapping(
+    source=UserDTO,
+    target=UserModel,
+    mapping={
+        "first_name": "firstName",
+        "last_name": "lastName",
+        "email_address": "emailAddress"
+    }
+)
+
+user_model = UserModel(
+    firstName="John",
+    lastName="Doe",
+    emailAddress="john.doe@example.com"
+)
+user_dto = mapper.map(user_model, UserDTO)
+```
+
 ### API Reference
 
 #### Mapper Class

--- a/src/pom/mapper.py
+++ b/src/pom/mapper.py
@@ -247,8 +247,16 @@ class Mapper:
         )
 
     def get_adapter(self, obj: Any):
-        if BaseModel is not None and (
-            isinstance(obj, BaseModel) or (isclass(obj) and issubclass(obj, BaseModel))
+        if (
+            BaseModel is not None
+            and (
+                isinstance(obj, BaseModel)
+                or (isclass(obj) and issubclass(obj, BaseModel))
+            )
+            or (
+                isinstance(obj, Iterable)
+                and all(isinstance(item, BaseModel) for item in obj)
+            )
         ):
             return PydanticModelAdapter(self.exclusions, BaseModel)
         return PopoAdapter(self.exclusions)

--- a/src/pom/mapper.py
+++ b/src/pom/mapper.py
@@ -277,9 +277,8 @@ class Mapper:
         )
 
     def get_adapter(self, obj: Any):
-        if (
-            BaseModel is not None
-            and (
+        if BaseModel is not None and (
+            (
                 isinstance(obj, BaseModel)
                 or (isclass(obj) and issubclass(obj, BaseModel))
             )

--- a/src/pom/mapper.py
+++ b/src/pom/mapper.py
@@ -35,8 +35,95 @@ MappingDict = Dict[str, Union[str, MapFunction]]
 MappingSpec = Union[MappingDict, Set[str]]
 
 
-class PydanticBaseModelAdapter:
-    def __init__(self, BaseModel: Type) -> None:
+class PopoAdapter:
+
+    def __init__(self, exclusions) -> None:
+        self.exclusions = exclusions
+
+    def get_init_params(self, obj: Union[Type, Any]) -> Set[Tuple[str, Any]]:
+        return {
+            (name, param)
+            for name, param in signature(obj.__init__).parameters.items()
+            if name != "self"
+        }
+
+    def get_source_attrs_names(self, source: Any) -> Set[str]:
+        if isinstance(source, Iterable) and not isinstance(source, (str, bytes)):
+            names = set()
+            for s in source:
+                pub = self.get_public_attrs(s)
+                init = self.get_init_params(s)
+                names |= {name for name, _ in pub} | {name for name, _ in init}
+            return names
+        pub = self.get_public_attrs(source)
+        init = self.get_init_params(source)
+        return {name for name, _ in pub} | {name for name, _ in init}
+
+    def get_source_type(self, source_instance: Any) -> SourceType:
+        return (
+            tuple(so if isclass(so) else type(so) for so in source_instance)
+            if self.is_collection(source_instance)
+            else source_instance if isclass(source_instance) else type(source_instance)
+        )
+
+    def is_collection(
+        self,
+        obj: Any,
+    ) -> bool:
+        # Default: treat any iterable (except strings/bytes) as multiple sources
+        if isinstance(obj, Iterable) and not isinstance(obj, (str, bytes)):
+            return True
+        # Single source
+        return False
+
+    def select_attrs(
+        self,
+        source: TS,
+        source_type: Union[Type[TS], Tuple[Type[TS], ...]],
+        target_type: Type[TT],
+    ) -> Dict[str, Any]:
+        return dict(
+            self._filter_out_excluded_attrs(
+                self.get_public_attrs(source), source_type, target_type
+            )
+        )
+
+    def _filter_out_excluded_attrs(
+        self,
+        attrs: List[Tuple[str, Any]],
+        source_type: Union[Type[TS], Tuple[Type[TS], ...]],
+        target_type: Type[TT],
+    ) -> List[Tuple[str, Any]]:
+        return [
+            attr
+            for attr in attrs
+            if attr[0] not in self.exclusions[source_type][target_type]
+        ]
+
+    def get_public_attrs(self, obj: Any) -> List[Tuple[str, Any]]:
+        return [attr for attr in getmembers(obj) if not attr[0].startswith("_")]
+
+    def get_attrs_names(self, attrs: Iterable[Tuple[str, Any]]) -> Set[str]:
+        return {name for name, _ in attrs}
+
+    def filter_empty_params(
+        self, init_params: Set[Tuple[str, Parameter]]
+    ) -> Set[Tuple[str, Parameter]]:
+        return {
+            (name, param)
+            for name, param in init_params
+            if param.default is Parameter.empty
+        }
+
+    def set_attrs(self, instance: TT, attrs: Mapping[str, Any]) -> TT:
+        for name, value in attrs.items():
+            setattr(instance, name, value)
+        return instance
+
+
+class PydanticModelAdapter(PopoAdapter):
+    def __init__(self, exclusions: Any, BaseModel: Type) -> None:
+        super().__init__(exclusions)
         self.BaseModel = BaseModel
 
     def get_public_attrs(self, obj: Any) -> List[Tuple[str, Any]]:
@@ -62,55 +149,27 @@ class PydanticBaseModelAdapter:
         init = self.get_init_params(source)
         return {name for name, _ in pub} | {name for name, _ in init}
 
-    def get_source_type(self, source_instance: Any) -> Type:
-        return (
-            type(source_instance) if not isclass(source_instance) else source_instance
-        )
-
     def filter_empty_params(
         self, init_params: Set[Tuple[str, Parameter]]
     ) -> Set[Tuple[str, Parameter]]:
         return {(name, param) for name, param in init_params if param is None}
 
-
-class POPOAdapter:
-    def get_public_attrs(self, obj: Any) -> List[Tuple[str, Any]]:
-        return [attr for attr in getmembers(obj) if not attr[0].startswith("_")]
-
-    def get_init_params(self, obj: Union[Type, Any]) -> Set[Tuple[str, Any]]:
-        return {
-            (name, param)
-            for name, param in signature(obj.__init__).parameters.items()
-            if name != "self"
-        }
-
-    def get_source_attrs_names(self, source: Any) -> Set[str]:
-        if isinstance(source, Iterable) and not isinstance(source, (str, bytes)):
-            names = set()
-            for s in source:
-                pub = self.get_public_attrs(s)
-                init = self.get_init_params(s)
-                names |= {name for name, _ in pub} | {name for name, _ in init}
-            return names
-        pub = self.get_public_attrs(source)
-        init = self.get_init_params(source)
-        return {name for name, _ in pub} | {name for name, _ in init}
-
-    def get_source_type(self, source_instance: Any) -> SourceType:
-        return (
-            tuple(so if isclass(so) else type(so) for so in source_instance)
-            if isinstance(source_instance, Iterable)
-            else source_instance if isclass(source_instance) else type(source_instance)
+    def is_collection(
+        self,
+        obj: Any,
+    ) -> bool:
+        # BaseModel instances/classes should always be treated as single sources
+        if (
+            isclass(obj)
+            and issubclass(obj, self.BaseModel)
+            or isinstance(obj, self.BaseModel)
+        ):
+            return False
+        elif isinstance(obj, Iterable) and not isinstance(obj, (str, bytes)):
+            return True
+        raise TypeError(
+            f"Expected a BaseModel instance, class or a collection of them, got {type(obj).__name__}"
         )
-
-    def filter_empty_params(
-        self, init_params: Set[Tuple[str, Parameter]]
-    ) -> Set[Tuple[str, Parameter]]:
-        return {
-            (name, param)
-            for name, param in init_params
-            if param.default is Parameter.empty
-        }
 
 
 def prop():
@@ -125,14 +184,6 @@ class Mapper:
         self.mappings = defaultdict(partial(defaultdict, partial(defaultdict, prop)))
         self.exclusions = defaultdict(partial(defaultdict, list))
 
-    @staticmethod
-    def _get_adapter(obj: Any):
-        if BaseModel is not None and (
-            isinstance(obj, BaseModel) or (isclass(obj) and issubclass(obj, BaseModel))
-        ):
-            return PydanticBaseModelAdapter(BaseModel)
-        return POPOAdapter()
-
     def add_mapping(
         self,
         *,
@@ -145,7 +196,8 @@ class Mapper:
         self._guard_source_has_all_attrs_specified_in_mapping(source, mapping)
         if isinstance(mapping, Set):
             mapping = {name: name for name in mapping}
-        source_type = self._get_source_type(source)
+        adapter = self.get_adapter(source)
+        source_type = adapter.get_source_type(source)
         self.mappings[source_type][target].update(mapping or {})
         self.exclusions[source_type][target].extend(exclusions or set())
 
@@ -168,14 +220,15 @@ class Mapper:
         target_is_type = isclass(target)
         target_type: type[TT] = target if target_is_type else type(target)
         skip_init = skip_init or not target_is_type
-        source_type = self._get_source_type(source)
+        adapter = self.get_adapter(target)
+        source_type = adapter.get_source_type(source)
 
         self._guard_no_required_attrs_excluded(
             source, target_type, source_type, extra, target
         )
 
         # Get source properties
-        source_attrs = self._build_source_attrs_chain_map(
+        source_attrs = self._create_source_attrs_chain_map(
             source, source_type, target_type
         )
 
@@ -183,17 +236,126 @@ class Mapper:
         mapping = self.mappings[source_type][target_type]
 
         # Apply mappings
-        mapped_attrs = self._map(mapping, source_attrs)
-
-        resulting_attrs = ChainMap(extra, mapped_attrs)
+        mapped_attrs = self._map(mapping, source_attrs, extra)
 
         return self._build_target(
             skip_init,
             target,
-            resulting_attrs,
+            mapped_attrs,
             target_type,
             source,
         )
+
+    def get_adapter(self, obj: Any):
+        if BaseModel is not None and (
+            isinstance(obj, BaseModel) or (isclass(obj) and issubclass(obj, BaseModel))
+        ):
+            return PydanticModelAdapter(self.exclusions, BaseModel)
+        return PopoAdapter(self.exclusions)
+
+    # region Private methods
+    # These methods are not intended to be used outside of this class.
+
+    def _map(
+        self, mappings: MappingDict, attrs: Mapping[str, Any], extra: Dict[str, Any]
+    ) -> Mapping[str, Any]:
+        result = []
+        for prop_name, prop_value in attrs.items():
+            transform = mappings[prop_name]
+            if callable(transform):
+                mapped_value = transform(prop_value)
+                result.append((prop_name, mapped_value))
+            elif isinstance(transform, str):
+                result.append((transform, prop_value))
+            elif isinstance(transform, tuple):
+                result.append((transform[0], transform[1](prop_value)))
+            else:
+                raise ValueError(
+                    f"Unsupported transform type for property '{prop_name}'."
+                )
+
+        return ChainMap(extra, dict(result))
+
+    def _create_source_attrs_chain_map(
+        self,
+        source: Any,
+        source_type: Any,
+        target_type: Any,
+    ) -> ChainMap:
+        adapter = self.get_adapter(source)
+
+        if adapter.is_collection(source):
+            return ChainMap(
+                *[adapter.select_attrs(so, source_type, target_type) for so in source]
+            )
+        # Single source
+        return ChainMap(adapter.select_attrs(source, source_type, target_type))
+
+    def _build_target(
+        self,
+        skip_init: bool,
+        target: Union[TT, Type[TT]],
+        mapped_attrs: Mapping[str, Any],
+        target_type: Type[TT],
+        source_instance: Union[TS, Tuple[TS, ...]],
+    ) -> TT:
+        # Create target instance
+        adapter = self.get_adapter(target)
+        try:
+            if skip_init:
+                if not isclass(target):
+                    return adapter.set_attrs(target, mapped_attrs)
+                else:
+                    target_instance = object.__new__(target_type)
+                    return adapter.set_attrs(target_instance, mapped_attrs)
+            return self._initialize_target(mapped_attrs, target_type)
+        except TypeError as e:
+            self._handle_mapping_error(source_instance, target_type, e)
+
+    def _initialize_target(
+        self,
+        mapped_attrs: Mapping[str, Any],
+        target_type: Type[TT],
+    ) -> TT:
+        adapter = self.get_adapter(target_type)
+        return target_type(
+            **{
+                k: v
+                for k, v in mapped_attrs.items()
+                if k
+                in set(adapter.get_attrs_names(adapter.get_init_params(target_type)))
+            },
+        )
+
+    def _guard_no_required_attrs_excluded(
+        self,
+        source_instance: Union[TS, Tuple[TS, ...]],
+        target_type: Type[TT],
+        source_type: Union[Type[TS], Tuple[Type[TS], ...]],
+        extra: Dict[str, Any],
+        target: Union[TT, Type[TT]],
+    ) -> None:
+        missing_attrs_candidates = set(self.exclusions[source_type][target_type]) - set(
+            extra.keys()
+        )
+
+        target_required_attrs = self._get_target_required_init_params_names(target)
+
+        missing_attrs = missing_attrs_candidates & target_required_attrs
+        if missing_attrs:
+            self._raise_required_attrs_excluded_error(
+                source_instance, target_type, missing_attrs
+            )
+
+    def _get_target_required_init_params_names(
+        self, target: Union[TT, Type[TT]]
+    ) -> Set[str]:
+        adapter = self.get_adapter(target)
+        t_props_names = adapter.get_attrs_names(
+            adapter.filter_empty_params(adapter.get_init_params(target))
+        ) - adapter.get_attrs_names(adapter.get_public_attrs(target))
+
+        return t_props_names
 
     def _guard_source_has_all_attrs_specified_in_mapping(
         self, source: Union[SourceType, TS], mapping: Optional[MappingSpec]
@@ -202,7 +364,8 @@ class Mapper:
             return
 
         mapping_attrs_names = self._get_mapping_attrs_names(mapping)
-        source_attrs_names = self._get_source_attrs_names(source)
+        adapter = self.get_adapter(source)
+        source_attrs_names = adapter.get_source_attrs_names(source)
         missing_attributes = {
             attr for attr in mapping_attrs_names if attr not in source_attrs_names
         }
@@ -218,17 +381,6 @@ class Mapper:
         raise RuntimeError(
             "Can't get mapping attributes names. Mapping expected to be a Dict or List like object"
         )
-
-    def _get_source_attrs_names(self, source: Any) -> Set[str]:
-        adapter = self._get_adapter(source)
-        return adapter.get_source_attrs_names(source)
-
-    def _get_attrs_names(self, attrs: Iterable[Tuple[str, Any]]) -> Set[str]:
-        return {name for name, _ in attrs}
-
-    def _get_init_params(self, obj: Union[Type, Any]) -> Set[Tuple[str, Any]]:
-        adapter = self._get_adapter(obj)
-        return adapter.get_init_params(obj)
 
     def _raise_missing_attrs_error(
         self, source: Union[SourceType, TS], missing_attributes: Set[str]
@@ -263,59 +415,6 @@ class Mapper:
             return type(source).__name__
         raise RuntimeError("Can't define source class name")
 
-    def _build_target(
-        self,
-        skip_init: bool,
-        target: Union[TT, Type[TT]],
-        mapped_attrs: Mapping[str, Any],
-        target_type: Type[TT],
-        source_instance: Union[TS, Tuple[TS, ...]],
-    ) -> TT:
-        # Create target instance
-        try:
-            if skip_init:
-                if not isclass(target):
-                    return self._set_attrs(target, mapped_attrs)
-                else:
-                    target_instance = object.__new__(target_type)
-                    return self._set_attrs(target_instance, mapped_attrs)
-            return self._initialize_target(mapped_attrs, target_type)
-        except TypeError as e:
-            self._handle_mapping_error(source_instance, target_type, e)
-
-    def _initialize_target(
-        self,
-        mapped_attrs: Mapping[str, Any],
-        target_type: Type[TT],
-    ) -> TT:
-        return target_type(
-            **{
-                k: v
-                for k, v in mapped_attrs.items()
-                if k in set(self._get_attrs_names(self._get_init_params(target_type)))
-            },
-        )
-
-    def _guard_no_required_attrs_excluded(
-        self,
-        source_instance: Union[TS, Tuple[TS, ...]],
-        target_type: Type[TT],
-        source_type: Union[Type[TS], Tuple[Type[TS], ...]],
-        extra: Dict[str, Any],
-        target: Union[TT, Type[TT]],
-    ) -> None:
-        missing_attrs_candidates = set(self.exclusions[source_type][target_type]) - set(
-            extra.keys()
-        )
-
-        target_required_attrs = self._get_target_required_init_params_names(target)
-
-        missing_attrs = missing_attrs_candidates & target_required_attrs
-        if missing_attrs:
-            self._raise_required_attrs_excluded_error(
-                source_instance, target_type, missing_attrs
-            )
-
     def _raise_required_attrs_excluded_error(
         self,
         source_instance: Union[TS, Tuple[TS, ...]],
@@ -333,48 +432,6 @@ class Mapper:
             raise RuntimeError(
                 f"{target_type.__name__} requires arguments {trouble_pros_names} which are excluded from mapping {source_name} -> {target_type.__name__}."
             )
-
-    def _get_source_type(self, source_instance: Any) -> SourceType:
-        adapter = self._get_adapter(source_instance)
-        return adapter.get_source_type(source_instance)
-
-    def _build_source_attrs_chain_map(
-        self,
-        source: Union[TS, Tuple[TS, ...]],
-        source_type: Union[Type[TS], Tuple[Type[TS], ...]],
-        target_type: Type[TT],
-    ) -> ChainMap:
-        """Extract properties from source object(s)."""
-
-        # This is necessary because BaseModel instances are iterables, but we want to treat them as single objects.
-        if BaseModel is not None:
-            if isinstance(source, BaseModel) or (
-                isclass(source) and issubclass(source, BaseModel)
-            ):
-                return ChainMap(self._select_attrs(source, source_type, target_type))
-
-        if isinstance(source, Iterable):
-            return ChainMap(
-                *[self._select_attrs(so, source_type, target_type) for so in source]
-            )
-        return ChainMap(self._select_attrs(source, source_type, target_type))
-
-    def _select_attrs(
-        self,
-        source: TS,
-        source_type: Union[Type[TS], Tuple[Type[TS], ...]],
-        target_type: Type[TT],
-    ) -> Dict[str, Any]:
-        return dict(
-            self._filter_out_excluded_attrs(
-                self._get_public_attrs(source), source_type, target_type
-            )
-        )
-
-    def _set_attrs(self, instance: TT, attrs: Mapping[str, Any]) -> TT:
-        for name, value in attrs.items():
-            setattr(instance, name, value)
-        return instance
 
     def _handle_mapping_error(
         self,
@@ -394,55 +451,4 @@ class Mapper:
             f"for target object {target_type.__name__}: {error}"
         )
 
-    def _get_public_attrs(self, obj: Any) -> List[Tuple[str, Any]]:
-        adapter = self._get_adapter(obj)
-        return adapter.get_public_attrs(obj)
-
-    def _filter_out_excluded_attrs(
-        self,
-        attrs: List[Tuple[str, Any]],
-        source_type: Union[Type[TS], Tuple[Type[TS], ...]],
-        target_type: Type[TT],
-    ) -> List[Tuple[str, Any]]:
-        return [
-            attr
-            for attr in attrs
-            if attr[0] not in self.exclusions[source_type][target_type]
-        ]
-
-    def _get_target_required_init_params_names(
-        self, target: Union[TT, Type[TT]]
-    ) -> Set[str]:
-        t_props_names = self._get_attrs_names(
-            self._filter_empty_params(self._get_init_params(target))
-        ) - self._get_attrs_names(self._get_public_attrs(target))
-
-        return t_props_names
-
-    def _filter_empty_params(
-        self, init_params: Set[Tuple[str, Parameter]]
-    ) -> Set[Tuple[str, Parameter]]:
-        return {
-            (name, param)
-            for name, param in init_params
-            # 'None' is used as a placeholder for Pydantic models in init_params to indicate
-            # that a parameter is missing or uninitialized. This allows us to filter out
-            # such parameters by checking 'param is None'.
-            if param is None or param.default is Parameter.empty
-        }
-
-    def _map(
-        self, maps: Dict[str, Callable], props: Mapping[str, Any]
-    ) -> Dict[str, Any]:
-        result = []
-        for prop_name, prop_value in props.items():
-            transform = maps[prop_name]
-            if callable(transform):
-                mapped_value = transform(prop_value)
-                result.append((prop_name, mapped_value))
-            if isinstance(transform, str):
-                result.append((transform, prop_value))
-            if isinstance(transform, tuple):
-                result.append((transform[0], transform[1](prop_value)))
-
-        return dict(result)
+    # endregion

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1219,3 +1219,30 @@ class TestPydanticMapping:
         assert result.name == "ynnhoJ"
         assert result.email == source.email
         assert result.age == source.age
+
+    def test_mapping_with_multiple_pydantic_models(self, mapper):
+        """Test mapping between multiple Pydantic models."""
+
+        class SourceModelA(BaseModel):
+            name: str
+            email: str
+
+        class SourceModelB(BaseModel):
+            age: int
+            address: str
+
+        class TargetModel(BaseModel):
+            name: str
+            email: str
+            age: int
+            address: str
+
+        source_a = SourceModelA(name="Johnny", email="johnny@email.com")
+        source_b = SourceModelB(age=30, address="123 Main St")
+        mapper.add_mapping(source=(SourceModelA, SourceModelB), target=TargetModel)
+        result = mapper.map((source_a, source_b), TargetModel)
+        assert isinstance(result, TargetModel)
+        assert result.name == source_a.name
+        assert result.email == source_a.email
+        assert result.age == source_b.age
+        assert result.address == source_b.address


### PR DESCRIPTION
This pull request introduces significant enhancements for mapping between Pydantic models and other object types, as well as extensive updates to the test suite to ensure robust validation and support for new features. Key changes include the addition of Pydantic model mapping capabilities, handling of field aliases, and improvements to the test coverage for various mapping scenarios.

### Enhancements to Pydantic Model Mapping:
* Added support for mapping between Pydantic models and other object types, including transformations and handling of field aliases. Detailed examples and explanations were added to the `README.md`.
* Introduced the `PydanticModelAdapter` to facilitate integration with Pydantic models, including methods for retrieving public attributes and initialization parameters.

### Improvements to Test Suite:
* Added comprehensive tests for mapping between Pydantic models and Plain Old Python Objects (POPOs), including validation scenarios, handling of required/excluded fields, and field aliasing.
* Extended test coverage for edge cases such as mapping multiple Pydantic models to a single target, skipping initialization during mapping, and ensuring compatibility with Pydantic's validation rules.
* Introduced tests for `PopoAdapter` to validate behavior with objects that have no `__init__`, use `*args` and `**kwargs`, or include properties and methods.

These changes significantly enhance the library's functionality and reliability, particularly for developers working with Pydantic models.