### PR TITLE
Add flag map_missing_fields to map for controlling the behaviour of missing fields on target class

### DIFF
--- a/src/pom/mapper.py
+++ b/src/pom/mapper.py
@@ -143,12 +143,6 @@ class PopoAdapter:
 
             return instance
 
-        if skip_init:
-            for name, value in attrs.items():
-                setattr(instance, name, value)
-
-            return instance
-
         init_param_names = set(self.get_attrs_names(self.get_init_params(instance)))
         if map_missing_fields:
             for name, value in attrs.items():

--- a/src/pom/mapper.py
+++ b/src/pom/mapper.py
@@ -134,7 +134,8 @@ class PopoAdapter:
             return instance
 
         if skip_init and not map_missing_fields:
-            public_attrs = self.get_public_attrs(instance)
+            public_attrs = self.get_attrs_names(self.get_public_attrs(instance))
+
             for name, value in attrs.items():
                 if name in public_attrs:
                     setattr(instance, name, value)
@@ -481,14 +482,14 @@ class Mapper:
         missing_attrs_candidates = set(self.exclusions[source_type][target_type]) - set(
             extra.keys()
         )
+        if not self.skip_init:
+            target_required_attrs = self._get_target_required_init_params_names(target)
 
-        target_required_attrs = self._get_target_required_init_params_names(target)
-
-        missing_attrs = missing_attrs_candidates & target_required_attrs
-        if missing_attrs:
-            self._raise_required_attrs_excluded_error(
-                source_instance, target_type, missing_attrs
-            )
+            missing_attrs = missing_attrs_candidates & target_required_attrs
+            if missing_attrs:
+                self._raise_required_attrs_excluded_error(
+                    source_instance, target_type, missing_attrs
+                )
 
     def _get_target_required_init_params_names(
         self, target: Union[TT, Type[TT]]

--- a/src/pom/mapper.py
+++ b/src/pom/mapper.py
@@ -351,12 +351,12 @@ class Mapper:
         extra = extra or {}
         target_is_type = isclass(target)
         target_type: type[TT] = target if target_is_type else type(target)
-        self.skip_init = skip_init or not target_is_type
+        skip_init = skip_init or not target_is_type
         adapter = self.get_adapter(source)
         source_type = adapter.get_source_type(source)
 
         self._guard_no_required_attrs_excluded(
-            source, target_type, source_type, extra, target
+            source, target_type, source_type, extra, target, skip_init
         )
 
         # Get source properties
@@ -371,7 +371,7 @@ class Mapper:
         mapped_attrs = self._map(mapping, source_attrs, extra)
 
         return self._build_target(
-            self.skip_init,
+            skip_init,
             target,
             mapped_attrs,
             target_type,
@@ -446,7 +446,7 @@ class Mapper:
             if skip_init:
                 if not isclass(target):
                     return adapter.set_attrs(
-                        target, mapped_attrs, map_missing_fields, self.skip_init
+                        target, mapped_attrs, map_missing_fields, skip_init
                     )
                 else:
                     target_instance = adapter.create_instance(target_type)
@@ -458,7 +458,7 @@ class Mapper:
                     )
 
             return adapter._initialize_target(
-                mapped_attrs, target_type, map_missing_fields, self.skip_init
+                mapped_attrs, target_type, map_missing_fields, skip_init
             )
         except TypeError as e:
             self._handle_mapping_error(source_instance, target_type, e)
@@ -472,11 +472,12 @@ class Mapper:
         source_type: Union[Type[TS], Tuple[Type[TS], ...]],
         extra: Dict[str, Any],
         target: Union[TT, Type[TT]],
+        skip_init: bool,
     ) -> None:
         missing_attrs_candidates = set(self.exclusions[source_type][target_type]) - set(
             extra.keys()
         )
-        if not self.skip_init:
+        if not skip_init:
             target_required_attrs = self._get_target_required_init_params_names(target)
 
             missing_attrs = missing_attrs_candidates & target_required_attrs

--- a/src/pom/mapper.py
+++ b/src/pom/mapper.py
@@ -119,11 +119,42 @@ class PopoAdapter:
         }
 
     def set_attrs(
-        self, instance: TT, attrs: Mapping[str, Any], map_missing_fields: bool
+        self,
+        instance: TT,
+        attrs: Mapping[str, Any],
+        map_missing_fields: bool,
+        skip_init: Optional[bool] = False,
     ) -> TT:
-        for name, value in attrs.items():
-            setattr(instance, name, value)
-        return instance
+        if skip_init and map_missing_fields:
+            for name, value in attrs.items():
+                setattr(instance, name, value)
+            return instance
+
+        if not skip_init and not map_missing_fields:
+            return instance
+
+        if skip_init and not map_missing_fields:
+            public_attrs = self.get_public_attrs(instance)
+            for name, value in attrs.items():
+                if name in public_attrs:
+                    setattr(instance, name, value)
+                continue
+
+            return instance
+
+        if skip_init:
+            for name, value in attrs.items():
+                setattr(instance, name, value)
+
+            return instance
+
+        init_param_names = set(self.get_attrs_names(self.get_init_params(instance)))
+        if map_missing_fields:
+            for name, value in attrs.items():
+                if name in init_param_names:
+                    continue
+                setattr(instance, name, value)
+            return instance
 
     def create_instance(self, cls: Type[TT]) -> TT:
         return object.__new__(cls)
@@ -133,15 +164,18 @@ class PopoAdapter:
         mapped_attrs: Mapping[str, Any],
         target_type: Type[TT],
         map_missing_fields: bool = False,
+        skip_init: Optional[bool] = False,
     ) -> TT:
 
-        return target_type(
+        instance = target_type(
             **{
                 k: v
                 for k, v in mapped_attrs.items()
                 if k in set(self.get_attrs_names(self.get_init_params(target_type)))
             },
         )
+
+        return self.set_attrs(instance, mapped_attrs, map_missing_fields, skip_init)
 
 
 class PydanticModelAdapter(PopoAdapter):
@@ -212,7 +246,11 @@ class PydanticModelAdapter(PopoAdapter):
         return cls.construct()
 
     def set_attrs(
-        self, instance: TT, attrs: Mapping[str, Any], map_missing_fields: bool
+        self,
+        instance: TT,
+        attrs: Mapping[str, Any],
+        map_missing_fields: bool,
+        skip_init: Optional[bool] = False,
     ) -> TT:
         model_allow_extra = instance.model_config.get("extra") == "allow"
         if map_missing_fields and not model_allow_extra:
@@ -239,10 +277,20 @@ class PydanticModelAdapter(PopoAdapter):
         mapped_attrs: Mapping[str, Any],
         target_type: Type[TT],
         map_missing_fields: bool = False,
+        skip_init: Optional[bool] = False,
     ) -> TT:
         if map_missing_fields and not target_type.model_config.get("extra") == "allow":
             raise ValueError(
                 f"Cannot initialize target model '{target_type.__name__}' with missing fields because it does not allow extra fields during initialization. (without model_config.extra='allow')"
+            )
+        if not map_missing_fields:
+
+            return target_type(
+                **{
+                    k: v
+                    for k, v in mapped_attrs.items()
+                    if k in set(self.get_attrs_names(self.get_init_params(target_type)))
+                },
             )
         return target_type(
             **{k: v for k, v in mapped_attrs.items()},
@@ -308,7 +356,7 @@ class Mapper:
         extra = extra or {}
         target_is_type = isclass(target)
         target_type: type[TT] = target if target_is_type else type(target)
-        skip_init = skip_init or not target_is_type
+        self.skip_init = skip_init or not target_is_type
         adapter = self.get_adapter(source)
         source_type = adapter.get_source_type(source)
 
@@ -328,7 +376,7 @@ class Mapper:
         mapped_attrs = self._map(mapping, source_attrs, extra)
 
         return self._build_target(
-            skip_init,
+            self.skip_init,
             target,
             mapped_attrs,
             target_type,
@@ -402,15 +450,20 @@ class Mapper:
         try:
             if skip_init:
                 if not isclass(target):
-                    return adapter.set_attrs(target, mapped_attrs, map_missing_fields)
+                    return adapter.set_attrs(
+                        target, mapped_attrs, map_missing_fields, self.skip_init
+                    )
                 else:
                     target_instance = adapter.create_instance(target_type)
                     return adapter.set_attrs(
-                        target_instance, mapped_attrs, map_missing_fields
+                        target_instance,
+                        mapped_attrs,
+                        map_missing_fields,
+                        skip_init,
                     )
 
             return adapter._initialize_target(
-                mapped_attrs, target_type, map_missing_fields=True
+                mapped_attrs, target_type, map_missing_fields, self.skip_init
             )
         except TypeError as e:
             self._handle_mapping_error(source_instance, target_type, e)

--- a/src/pom/mapper.py
+++ b/src/pom/mapper.py
@@ -252,13 +252,12 @@ class PydanticModelAdapter(PopoAdapter):
             raise ValueError(
                 f"Cannot map missing fields on target model '{type(instance).__name__}' because it does not allow extra fields."
             )
+        target_fields = instance.model_fields
 
         for name, value in attrs.items():
             if map_missing_fields and model_allow_extra:
                 setattr(instance, name, value)
                 continue
-
-            target_fields = instance.model_fields
             if map_missing_fields is False:
                 if name not in target_fields:
                     continue

--- a/src/pom/mapper.py
+++ b/src/pom/mapper.py
@@ -118,7 +118,9 @@ class PopoAdapter:
             if param.default is Parameter.empty
         }
 
-    def set_attrs(self, instance: TT, attrs: Mapping[str, Any]) -> TT:
+    def set_attrs(
+        self, instance: TT, attrs: Mapping[str, Any], map_missing_fields: bool
+    ) -> TT:
         for name, value in attrs.items():
             setattr(instance, name, value)
         return instance
@@ -126,9 +128,28 @@ class PopoAdapter:
     def create_instance(self, cls: Type[TT]) -> TT:
         return object.__new__(cls)
 
+    def _initialize_target(
+        self,
+        mapped_attrs: Mapping[str, Any],
+        target_type: Type[TT],
+        map_missing_fields: bool = False,
+    ) -> TT:
+
+        return target_type(
+            **{
+                k: v
+                for k, v in mapped_attrs.items()
+                if k in set(self.get_attrs_names(self.get_init_params(target_type)))
+            },
+        )
+
 
 class PydanticModelAdapter(PopoAdapter):
-    def __init__(self, exclusions: Any, BaseModel: Type) -> None:
+    def __init__(
+        self,
+        exclusions: Any,
+        BaseModel: Type,
+    ) -> None:
         super().__init__(exclusions)
         self.BaseModel = BaseModel
 
@@ -190,6 +211,43 @@ class PydanticModelAdapter(PopoAdapter):
             raise TypeError("Expected a Pydantic BaseModel class")
         return cls.construct()
 
+    def set_attrs(
+        self, instance: TT, attrs: Mapping[str, Any], map_missing_fields: bool
+    ) -> TT:
+        model_allow_extra = instance.model_config.get("extra") == "allow"
+        if map_missing_fields and not model_allow_extra:
+            raise ValueError(
+                f"Cannot map missing fields on target model '{type(instance).__name__}' because it does not allow extra fields."
+            )
+
+        for name, value in attrs.items():
+            if map_missing_fields and model_allow_extra:
+                setattr(instance, name, value)
+                continue
+
+            target_fields = instance.model_fields
+            if map_missing_fields is False:
+                if name not in target_fields:
+                    continue
+
+            setattr(instance, name, value)
+
+        return instance
+
+    def _initialize_target(
+        self,
+        mapped_attrs: Mapping[str, Any],
+        target_type: Type[TT],
+        map_missing_fields: bool = False,
+    ) -> TT:
+        if map_missing_fields and not target_type.model_config.get("extra") == "allow":
+            raise ValueError(
+                f"Cannot initialize target model '{target_type.__name__}' with missing fields because it does not allow extra fields during initialization. (without model_config.extra='allow')"
+            )
+        return target_type(
+            **{k: v for k, v in mapped_attrs.items()},
+        )
+
     @staticmethod
     def _get_obj_fields(obj):
         return {(field.alias or name, field) for name, field in obj.__fields__.items()}
@@ -237,6 +295,7 @@ class Mapper:
         target: Union[TT, type[TT]],
         skip_init: bool = False,
         extra: Optional[dict] = None,
+        map_missing_fields: bool = False,
     ) -> TT:
         """Map source object(s) to target type.
 
@@ -274,6 +333,7 @@ class Mapper:
             mapped_attrs,
             target_type,
             source,
+            map_missing_fields,
         )
 
     def get_adapter(self, obj: Any):
@@ -335,36 +395,27 @@ class Mapper:
         mapped_attrs: Mapping[str, Any],
         target_type: Type[TT],
         source_instance: Union[TS, Tuple[TS, ...]],
+        map_missing_fields: bool = False,
     ) -> TT:
         # Create target instance
         adapter = self.get_adapter(target)
         try:
             if skip_init:
                 if not isclass(target):
-                    return adapter.set_attrs(target, mapped_attrs)
+                    return adapter.set_attrs(target, mapped_attrs, map_missing_fields)
                 else:
                     target_instance = adapter.create_instance(target_type)
-                    return adapter.set_attrs(target_instance, mapped_attrs)
-            return self._initialize_target(mapped_attrs, target_type)
+                    return adapter.set_attrs(
+                        target_instance, mapped_attrs, map_missing_fields
+                    )
+
+            return adapter._initialize_target(
+                mapped_attrs, target_type, map_missing_fields=True
+            )
         except TypeError as e:
             self._handle_mapping_error(source_instance, target_type, e)
         except AttributeError as e:
             raise
-
-    def _initialize_target(
-        self,
-        mapped_attrs: Mapping[str, Any],
-        target_type: Type[TT],
-    ) -> TT:
-        adapter = self.get_adapter(target_type)
-        return target_type(
-            **{
-                k: v
-                for k, v in mapped_attrs.items()
-                if k
-                in set(adapter.get_attrs_names(adapter.get_init_params(target_type)))
-            },
-        )
 
     def _guard_no_required_attrs_excluded(
         self,

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -587,7 +587,7 @@ class TestAdvancedMapping:
                 source=Source, target=Target, mapping={"name": reversed_string}
             )
 
-    def test_mapping_from_source_instance_should_not_set_attrs_that_not_has_been_initialized(
+    def test_mapping_from_source_instance_should_not_set_attrs_that_have_not_been_initialized(
         self, mapper, reversed_string
     ):
         """
@@ -639,7 +639,7 @@ class TestAdvancedMapping:
         assert isinstance(b, Target)
         assert b.name == "ynnhoJ"
 
-    def test_mapping_from_multiple_source_instances_should_not_set_attrs_that_not_has_been_initialized(
+    def test_mapping_from_multiple_source_instances_should_not_set_attrs_that_have_not_been_initialized(
         self, mapper, reversed_string
     ):
         """

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1630,6 +1630,7 @@ class TestPydanticMapping:
             age: int
 
             @field_validator("age")
+            @classmethod
             def age_must_be_positive(cls, v):
                 if v < 0:
                     raise ValueError("age must be positive")

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -100,6 +100,8 @@ class TestBasicMapping:
     def test_map_popo_to_popo_skip_init(self, mapper):
         """Test mapping to a POPO target with skip_init=True."""
 
+        # TODO Esse teste está quebrando pois como o skip_init é True, e o map_missing_fields é false, no momento de atribuir os valores da Source no Target
+        # não é possível identificar que o value da Target existe, pois seu __init__ não foi executado. E isso é esperado
         class Source:
             def __init__(self, value: str):
                 self.value = value
@@ -123,34 +125,8 @@ class TestBasicMapping:
             target_instance, "initialized"
         )  # __init__ should not have been called
 
-        # Verify it can set attributes not in __init__ if they exist on the class
-        # For this to work, Target needs to be prepared to have attributes set directly
-        # or the adapter's set_attrs needs to handle it.
-        # Let's assume direct attribute setting for now.
-        target_instance_with_extra = Target()  # Create a normal instance to compare
-        target_instance_with_extra.extra_field = "set_via_map"
-
-        mapper_extra = Mapper()
-
-        class SourceWithExtra:
-            def __init__(self, extra_field: str):
-                self.extra_field = extra_field
-
-        source_extra_instance = SourceWithExtra(extra_field="set_via_map")
-        mapper_extra.add_mapping(source=SourceWithExtra, target=Target)
-
-        # Target class needs 'extra_field' defined if we expect it to be set
-        # For simplicity, let's assume Target has it.
-        # If Target doesn't have `extra_field` defined, this would typically set it dynamically.
-        Target.extra_field = None  # Ensure the attribute exists for setattr
-
-        target_mapped_extra = mapper_extra.map(
-            source_extra_instance, Target, skip_init=True
-        )
-        assert target_mapped_extra.extra_field == "set_via_map"
-
-    def test_map_without_add_mapping_map_equal_attrs(self, mapper):
-        """Test that calling map without adding a mapping maps everything that is equal to both source and target."""
+    def test_map_without_add_mapping_dict_map_equal_attrs(self, mapper):
+        """Test that calling map without adding a mapping dict maps everything that is equal to both source and target."""
 
         class SourceModel:
             def __init__(self, name: str, age: int) -> None:
@@ -1915,7 +1891,7 @@ class TestPydanticModelAdapter:
         assert hasattr(result, "age")
         assert hasattr(result, "extra_field")
 
-    def test_pydantic_adapter_object_without_source_fields_not_allowing_model_extra_and_flag_map_missing_fields_true(
+    def test_pydantic_target_model_object_without_source_fields_not_allowing_model_extra_and_flag_map_missing_fields_true(
         self, mapper
     ):
         class TargetPydanticModel(BaseModel):
@@ -1935,7 +1911,7 @@ class TestPydanticModelAdapter:
         ):
             mapper.map(source, target, map_missing_fields=True)
 
-    def test_pydantic_adapter_object_without_source_fields_allowing_model_extra_and_flag_map_missing_fields_false(
+    def test_pydantic_target_model_object_without_source_fields_allowing_model_extra_and_flag_map_missing_fields_false(
         self, mapper
     ):
         class TargetPydanticModel(BaseModel):
@@ -1957,7 +1933,7 @@ class TestPydanticModelAdapter:
         assert hasattr(result, "age")
         assert not hasattr(result, "extra_field")
 
-    def test_pydantic_adapter_object_without_source_fields_not_allowing_model_extra_and_flag_map_missing_fields_false(
+    def test_pydantic_target_model_object_without_source_fields_not_allowing_model_extra_and_flag_map_missing_fields_false(
         self, mapper
     ):
         class TargetPydanticModel(BaseModel):
@@ -1979,7 +1955,7 @@ class TestPydanticModelAdapter:
         assert hasattr(result, "age")
         assert not hasattr(result, "extra_field")
 
-    def test_pydantic_adapter_class_without_source_fields_allowing_model_extra_and_flag_map_missing_fields_true(
+    def test_pydantic_target_model_class_without_source_fields_allowing_model_extra_and_flag_map_missing_fields_true(
         self, mapper
     ):
         class TargetPydanticModel(BaseModel):
@@ -1998,9 +1974,9 @@ class TestPydanticModelAdapter:
 
         assert hasattr(result, "name")
         assert hasattr(result, "age")
-        assert not hasattr(result, "extra_field")
+        assert hasattr(result, "extra_field")
 
-    def test_pydantic_adapter_class_without_source_fields_not_allowing_model_extra_and_flag_map_missing_fields_true(
+    def test_pydantic_target_model_class_without_source_fields_not_allowing_model_extra_and_flag_map_missing_fields_true(
         self, mapper
     ):
         class TargetPydanticModel(BaseModel):
@@ -2016,7 +1992,7 @@ class TestPydanticModelAdapter:
         with pytest.raises(ValueError):
             mapper.map(source, TargetPydanticModel, map_missing_fields=True)
 
-    def test_pydantic_adapter_class_without_source_fields_allowing_model_extra_and_flag_map_missing_fields_false(
+    def test_pydantic_target_model_class_without_source_fields_allowing_model_extra_and_flag_map_missing_fields_false(
         self, mapper
     ):
         class TargetPydanticModel(BaseModel):
@@ -2034,9 +2010,9 @@ class TestPydanticModelAdapter:
 
         assert hasattr(result, "name")
         assert hasattr(result, "age")
-        assert hasattr(result, "extra_field")
+        assert not hasattr(result, "extra_field")
 
-    def test_pydantic_adapter_class_without_source_fields_not_allowing_model_extra_and_flag_map_missing_fields_false(
+    def test_pydantic_target_model_class_without_source_fields_not_allowing_model_extra_and_flag_map_missing_fields_false(
         self, mapper
     ):
         class TargetPydanticModel(BaseModel):
@@ -2147,12 +2123,13 @@ class TestAdapterSelection:
 class TestMapMissingFieldsEdgeCases:
     """Tests for edge cases with map_missing_fields flag."""
 
-    def test_popo_map_missing_fields_without_skip_init_raises_error(self, mapper):
+    def test_popo_map_missing_fields_without_skip_init_should_set_missing_fields(
+        self, mapper
+    ):
         """
-        CRITICAL BUG: Verify that map_missing_fields=True fails without skip_init for POPOs.
-
-        This test evidences that users will get confusing TypeError when trying to use
-        map_missing_fields=True without skip_init=True on regular Python classes.
+        Given PopoClasses on target and source
+        When flag map_missing_fields is True
+        Then the result must have extra fields
         """
 
         class Source:
@@ -2166,9 +2143,119 @@ class TestMapMissingFieldsEdgeCases:
 
         source = Source("Test", "extra_value")
 
-        # This should fail with TypeError about unexpected keyword argument
-        with pytest.raises(TypeError, match="unexpected keyword argument"):
-            mapper.map(source, Target, map_missing_fields=True)
+        result = mapper.map(source, Target, map_missing_fields=True)
+        assert hasattr(result, "name")
+        assert hasattr(result, "extra")
+
+    def test_popo_map_missing_fields_without_skip_init_and_allowing_missing_fields_should_not_overwrite_target_values(
+        self, mapper
+    ):
+        """
+        Given PopoClasses on target and source
+        When flag map_missing_fields is True
+        Then the result must have extra fields
+        """
+
+        class Source:
+            def __init__(self, name: str, extra: str):
+                self.name = name
+                self.extra = extra
+
+        class Target:
+            def __init__(self, name: str):
+                self.name = "should not overwrite"
+
+        source = Source("source name value", "extra_value")
+
+        result = mapper.map(source, Target, map_missing_fields=True)
+        assert hasattr(result, "name")
+        assert hasattr(result, "extra")
+        assert getattr(result, "name") == "should not overwrite"
+
+    def test_popo_map_missing_fields_with_skip_init_and_allowing_missing_fields_should_overwrite_target_values_that_does_not_exist_in_init_signature(
+        self, mapper
+    ):
+        """
+        Given PopoClasses on target and source
+        When flag map_missing_fields is True
+        Then the result must have extra fields
+        """
+
+        class Source:
+            def __init__(self, name: str, extra: str, age: int):
+                self.name = name
+                self.extra = extra
+                self.age = age
+
+        class Target:
+            def __init__(self, name: str):
+                self.name = "should not overwrite"
+                self.age = 9999
+
+        source = Source("source name value", "extra_value", 0)
+
+        result = mapper.map(source, Target, map_missing_fields=True, skip_init=True)
+        assert hasattr(result, "name")
+        assert hasattr(result, "extra")
+        assert hasattr(result, "age")
+        assert getattr(result, "age") == 0
+
+    def test_popo_map_missing_fields_without_skip_init_allowing_missing_fields_should_not_overwrite_target_values(
+        self, mapper
+    ):
+        """
+        Given PopoClasses on target and source
+        When flag map_missing_fields is True and skip_init is False (default)
+        Then the result should not ovewrite target values
+        """
+
+        class Source:
+            def __init__(self, name: str, extra: str, age: int):
+                self.name = name
+                self.extra = extra
+                self.age = age
+
+        class Target:
+            def __init__(self, name: str, age: int):
+                self.name = "should not overwrite"
+                self.age = age * 2
+
+        source = Source("source name value", "extra_value", 2)
+
+        result = mapper.map(source, Target, map_missing_fields=True)
+        assert hasattr(result, "name")
+        assert hasattr(result, "extra")
+        assert hasattr(result, "age")
+        assert getattr(result, "age") == 4
+
+    def test_popo_map_missing_fields_without_skip_init_not_allowing_missing_fields_should_not_overwrite_target_values(
+        self, mapper
+    ):
+        """
+        Given PopoClasses on target and source
+        When flag map_missing_fields is True and skip_init is False (default)
+        Then the result should not ovewrite target values
+        """
+
+        class Source:
+            def __init__(self, name: str, extra: str, age: int):
+                self.name = name
+                self.extra = extra
+                self.age = age
+
+        class Target:
+            def __init__(self, name: str, age: int):
+                self.name = "should not overwrite"
+                self.age = age * 2
+
+        source = Source("source name value", "extra_value", 2)
+
+        result = mapper.map(source, Target)
+        assert hasattr(result, "name")
+        assert not hasattr(result, "extra")
+        assert hasattr(result, "age")
+        assert getattr(result, "age") == 4
+        assert getattr(result, "name") == "should not overwrite"
 
     def test_popo_map_missing_fields_with_skip_init_succeeds(self, mapper):
         """
@@ -2245,11 +2332,9 @@ class TestMapMissingFieldsEdgeCases:
         source = SourceModel(name="Test", extra_field="extra")
 
         # Case 1: Target as CLASS with map_missing_fields=False
-        # Expected: extra_field IS mapped (Pydantic's default behavior during __init__)
+        # Expected: extra_field IS NOT mapped (Because the user explicity defined to not map extra fields)
         result_class_false = mapper.map(source, TargetModel, map_missing_fields=False)
-        assert hasattr(result_class_false, "extra_field")
-        assert result_class_false.extra_field == "extra"
-        print("✓ Class + map_missing_fields=False: extra field MAPPED")
+        assert not hasattr(result_class_false, "extra_field")
 
         # Case 2: Target as INSTANCE with map_missing_fields=False
         # Expected: extra_field is NOT mapped
@@ -2258,13 +2343,11 @@ class TestMapMissingFieldsEdgeCases:
             source, target_instance, map_missing_fields=False
         )
         assert not hasattr(result_instance_false, "extra_field")
-        print("✓ Instance + map_missing_fields=False: extra field NOT mapped")
 
         # Case 3: Target as CLASS with map_missing_fields=True
-        # Expected: extra_field is NOT mapped (because of validation during __init__)
+        # Expected: extra_field is mapped
         result_class_true = mapper.map(source, TargetModel, map_missing_fields=True)
-        assert not hasattr(result_class_true, "extra_field")
-        print("✓ Class + map_missing_fields=True: extra field NOT mapped")
+        assert hasattr(result_class_true, "extra_field")
 
         # Case 4: Target as INSTANCE with map_missing_fields=True
         # Expected: extra_field IS mapped
@@ -2274,7 +2357,6 @@ class TestMapMissingFieldsEdgeCases:
         )
         assert hasattr(result_instance_true, "extra_field")
         assert result_instance_true.extra_field == "extra"
-        print("✓ Instance + map_missing_fields=True: extra field MAPPED")
 
     def test_multiple_sources_with_map_missing_fields(self, mapper):
         """Test map_missing_fields with multiple sources."""

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,3 +1,4 @@
+from time import perf_counter
 import unittest.mock
 from contextlib import nullcontext as does_not_raise
 from dataclasses import dataclass
@@ -1458,13 +1459,12 @@ class TestAdvancedMapping:
         source = LargeSource()
         mapper.add_mapping(source=source, target=LargeTarget)
 
-        import time
-
-        start = time.time()
+        start = perf_counter()
         result = mapper.map(
             source, LargeTarget, skip_init=True, map_missing_fields=True
         )
-        duration = time.time() - start
+        end = perf_counter()
+        duration = end - start
         assert duration < 1.0  # Should complete in under 1 second
         assert all(getattr(result, f"attr_{i}") == i for i in range(100000))
 

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -2323,7 +2323,7 @@ class TestMapMissingFieldsEdgeCases:
         """
         Given PopoClasses on target and source
         When flag map_missing_fields is True and skip_init is False (default)
-        Then the result should not ovewrite target values
+        Then the result should not overwrite target values
         """
 
         class Source:
@@ -2351,7 +2351,7 @@ class TestMapMissingFieldsEdgeCases:
         """
         Given PopoClasses on target and source
         When flag map_missing_fields is True and skip_init is False (default)
-        Then the result should not ovewrite target values
+        Then the result should not overwrite target values
         """
 
         class Source:

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -103,8 +103,6 @@ class TestBasicMapping:
     ):
         """Test mapping to a POPO target with skip_init=True."""
 
-        # TODO Esse teste está quebrando pois como o skip_init é True, e o map_missing_fields é false, no momento de atribuir os valores da Source no Target
-        # não é possível identificar que o value da Target existe, pois seu __init__ não foi executado. E isso é esperado
         class Source:
             def __init__(self, value: str, class_field: str = "set"):
                 self.value = value

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -2428,14 +2428,14 @@ class TestMapMissingFieldsEdgeCases:
 
     def test_pydantic_class_vs_instance_target_behavior_difference(self, mapper):
         """
-        CRITICAL INCONSISTENCY: Pydantic behaves differently when target is class vs instance.
+        Verify behavior when mapping to Pydantic targets as classes vs instances
+        with different values of map_missing_fields.
 
-        - Target as CLASS + map_missing_fields=False: extra fields ARE mapped (Pydantic default)
+        Expected behavior being tested:
+        - Target as CLASS + map_missing_fields=False: extra fields are NOT mapped
         - Target as INSTANCE + map_missing_fields=False: extra fields are NOT mapped
-        - Target as CLASS + map_missing_fields=True: extra fields are NOT mapped
+        - Target as CLASS + map_missing_fields=True: extra fields ARE mapped
         - Target as INSTANCE + map_missing_fields=True: extra fields ARE mapped
-
-        This inconsistency is confusing and NOT documented.
         """
 
         class SourceModel(BaseModel):

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1893,6 +1893,168 @@ class TestPydanticModelAdapter:
         assert isinstance(adapter, PydanticModelAdapter)
         assert set(attrs) == set()  # No fields with defaults
 
+    def test_pydantic_adapter_object_without_source_fields_allowing_model_extra_and_flag_map_missing_fields_true(
+        self, mapper
+    ):
+        class TargetPydanticModel(BaseModel):
+            model_config = {"extra": "allow"}
+            name: str
+            age: int
+
+        class SourcePydanticModel(BaseModel):
+            name: str
+            age: int
+            extra_field: str
+
+        target = TargetPydanticModel(name="Name1", age=34)
+        source = SourcePydanticModel(name="Name2", age=25, extra_field="extra")
+
+        result = mapper.map(source, target, map_missing_fields=True)
+
+        assert hasattr(result, "name")
+        assert hasattr(result, "age")
+        assert hasattr(result, "extra_field")
+
+    def test_pydantic_adapter_object_without_source_fields_not_allowing_model_extra_and_flag_map_missing_fields_true(
+        self, mapper
+    ):
+        class TargetPydanticModel(BaseModel):
+            name: str
+            age: int
+
+        class SourcePydanticModel(BaseModel):
+            name: str
+            age: int
+            extra_field: str
+
+        target = TargetPydanticModel(name="Name1", age=34)
+        source = SourcePydanticModel(name="Name2", age=25, extra_field="extra")
+
+        with pytest.raises(
+            ValueError, match="Cannot map missing fields on target model"
+        ):
+            mapper.map(source, target, map_missing_fields=True)
+
+    def test_pydantic_adapter_object_without_source_fields_allowing_model_extra_and_flag_map_missing_fields_false(
+        self, mapper
+    ):
+        class TargetPydanticModel(BaseModel):
+            model_config = {"extra": "allow"}
+            name: str
+            age: int
+
+        class SourcePydanticModel(BaseModel):
+            name: str
+            age: int
+            extra_field: str
+
+        target = TargetPydanticModel(name="Name1", age=34)
+        source = SourcePydanticModel(name="Name2", age=25, extra_field="extra")
+
+        result = mapper.map(source, target)
+
+        assert hasattr(result, "name")
+        assert hasattr(result, "age")
+        assert not hasattr(result, "extra_field")
+
+    def test_pydantic_adapter_object_without_source_fields_not_allowing_model_extra_and_flag_map_missing_fields_false(
+        self, mapper
+    ):
+        class TargetPydanticModel(BaseModel):
+
+            name: str
+            age: int
+
+        class SourcePydanticModel(BaseModel):
+            name: str
+            age: int
+            extra_field: str
+
+        target = TargetPydanticModel(name="Name1", age=34)
+        source = SourcePydanticModel(name="Name2", age=25, extra_field="extra")
+
+        result = mapper.map(source, target)
+
+        assert hasattr(result, "name")
+        assert hasattr(result, "age")
+        assert not hasattr(result, "extra_field")
+
+    def test_pydantic_adapter_class_without_source_fields_allowing_model_extra_and_flag_map_missing_fields_true(
+        self, mapper
+    ):
+        class TargetPydanticModel(BaseModel):
+            model_config = {"extra": "allow"}
+            name: str
+            age: int
+
+        class SourcePydanticModel(BaseModel):
+            name: str
+            age: int
+            extra_field: str
+
+        source = SourcePydanticModel(name="Name2", age=25, extra_field="extra")
+
+        result = mapper.map(source, TargetPydanticModel, map_missing_fields=True)
+
+        assert hasattr(result, "name")
+        assert hasattr(result, "age")
+        assert not hasattr(result, "extra_field")
+
+    def test_pydantic_adapter_class_without_source_fields_not_allowing_model_extra_and_flag_map_missing_fields_true(
+        self, mapper
+    ):
+        class TargetPydanticModel(BaseModel):
+            name: str
+            age: int
+
+        class SourcePydanticModel(BaseModel):
+            name: str
+            age: int
+            extra_field: str
+
+        source = SourcePydanticModel(name="Name2", age=25, extra_field="extra")
+        with pytest.raises(ValueError):
+            mapper.map(source, TargetPydanticModel, map_missing_fields=True)
+
+    def test_pydantic_adapter_class_without_source_fields_allowing_model_extra_and_flag_map_missing_fields_false(
+        self, mapper
+    ):
+        class TargetPydanticModel(BaseModel):
+            model_config = {"extra": "allow"}
+            name: str
+            age: int
+
+        class SourcePydanticModel(BaseModel):
+            name: str
+            age: int
+            extra_field: str
+
+        source = SourcePydanticModel(name="Name2", age=25, extra_field="extra")
+        result = mapper.map(source, TargetPydanticModel)
+
+        assert hasattr(result, "name")
+        assert hasattr(result, "age")
+        assert hasattr(result, "extra_field")
+
+    def test_pydantic_adapter_class_without_source_fields_not_allowing_model_extra_and_flag_map_missing_fields_false(
+        self, mapper
+    ):
+        class TargetPydanticModel(BaseModel):
+            name: str
+            age: int
+
+        class SourcePydanticModel(BaseModel):
+            name: str
+            age: int
+            extra_field: str
+
+        source = SourcePydanticModel(name="Name2", age=25, extra_field="extra")
+        result = mapper.map(source, TargetPydanticModel)
+
+        assert hasattr(result, "name")
+        assert hasattr(result, "age")
+        assert not hasattr(result, "extra_field")
+
 
 class TestPopoAdapter:
     def test_popo_adapter_get_init_params_variations(self, mapper):
@@ -1980,3 +2142,352 @@ class TestAdapterSelection:
         adapter_iterable = mapper.get_adapter(iterable)
         assert not isinstance(adapter_iterable, PydanticModelAdapter)
         assert isinstance(adapter_iterable, mapper.get_adapter(SomeClass()).__class__)
+
+
+class TestMapMissingFieldsEdgeCases:
+    """Tests for edge cases with map_missing_fields flag."""
+
+    def test_popo_map_missing_fields_without_skip_init_raises_error(self, mapper):
+        """
+        CRITICAL BUG: Verify that map_missing_fields=True fails without skip_init for POPOs.
+
+        This test evidences that users will get confusing TypeError when trying to use
+        map_missing_fields=True without skip_init=True on regular Python classes.
+        """
+
+        class Source:
+            def __init__(self, name: str, extra: str):
+                self.name = name
+                self.extra = extra
+
+        class Target:
+            def __init__(self, name: str):
+                self.name = name
+
+        source = Source("Test", "extra_value")
+
+        # This should fail with TypeError about unexpected keyword argument
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            mapper.map(source, Target, map_missing_fields=True)
+
+    def test_popo_map_missing_fields_with_skip_init_succeeds(self, mapper):
+        """
+        Verify that map_missing_fields=True WORKS with skip_init=True for POPOs.
+        This is the CORRECT way to use map_missing_fields with POPOs.
+        """
+
+        class Source:
+            def __init__(self, name: str, extra: str):
+                self.name = name
+                self.extra = extra
+
+        class Target:
+            def __init__(self, name: str):
+                self.name = name
+
+        source = Source("Test", "extra_value")
+
+        # This should succeed
+        result = mapper.map(source, Target, skip_init=True, map_missing_fields=True)
+
+        assert result.name == "Test"
+        assert result.extra == "extra_value"
+
+    def test_extra_parameter_overrides_map_missing_fields(self, mapper):
+        """
+        IMPORTANT: Verify that extra parameter takes precedence over map_missing_fields.
+        This behavior is NOT documented and can confuse users.
+        """
+
+        class Source:
+            def __init__(self, name: str, field: str):
+                self.name = name
+                self.field = "from_source"
+
+        class Target:
+            def __init__(self, name: str):
+                self.name = name
+
+        source = Source("Test", "from_source")
+
+        result = mapper.map(
+            source,
+            Target,
+            skip_init=True,
+            map_missing_fields=True,
+            extra={"field": "from_extra"},
+        )
+
+        # extra parameter should override the source value
+        assert result.field == "from_extra"  # NOT "from_source"
+        assert result.name == "Test"
+
+    def test_pydantic_class_vs_instance_target_behavior_difference(self, mapper):
+        """
+        CRITICAL INCONSISTENCY: Pydantic behaves differently when target is class vs instance.
+
+        - Target as CLASS + map_missing_fields=False: extra fields ARE mapped (Pydantic default)
+        - Target as INSTANCE + map_missing_fields=False: extra fields are NOT mapped
+        - Target as CLASS + map_missing_fields=True: extra fields are NOT mapped
+        - Target as INSTANCE + map_missing_fields=True: extra fields ARE mapped
+
+        This inconsistency is confusing and NOT documented.
+        """
+
+        class SourceModel(BaseModel):
+            name: str
+            extra_field: str
+
+        class TargetModel(BaseModel):
+            model_config = {"extra": "allow"}
+            name: str
+
+        source = SourceModel(name="Test", extra_field="extra")
+
+        # Case 1: Target as CLASS with map_missing_fields=False
+        # Expected: extra_field IS mapped (Pydantic's default behavior during __init__)
+        result_class_false = mapper.map(source, TargetModel, map_missing_fields=False)
+        assert hasattr(result_class_false, "extra_field")
+        assert result_class_false.extra_field == "extra"
+        print("✓ Class + map_missing_fields=False: extra field MAPPED")
+
+        # Case 2: Target as INSTANCE with map_missing_fields=False
+        # Expected: extra_field is NOT mapped
+        target_instance = TargetModel(name="Original")
+        result_instance_false = mapper.map(
+            source, target_instance, map_missing_fields=False
+        )
+        assert not hasattr(result_instance_false, "extra_field")
+        print("✓ Instance + map_missing_fields=False: extra field NOT mapped")
+
+        # Case 3: Target as CLASS with map_missing_fields=True
+        # Expected: extra_field is NOT mapped (because of validation during __init__)
+        result_class_true = mapper.map(source, TargetModel, map_missing_fields=True)
+        assert not hasattr(result_class_true, "extra_field")
+        print("✓ Class + map_missing_fields=True: extra field NOT mapped")
+
+        # Case 4: Target as INSTANCE with map_missing_fields=True
+        # Expected: extra_field IS mapped
+        target_instance2 = TargetModel(name="Original")
+        result_instance_true = mapper.map(
+            source, target_instance2, map_missing_fields=True
+        )
+        assert hasattr(result_instance_true, "extra_field")
+        assert result_instance_true.extra_field == "extra"
+        print("✓ Instance + map_missing_fields=True: extra field MAPPED")
+
+    def test_multiple_sources_with_map_missing_fields(self, mapper):
+        """Test map_missing_fields with multiple sources."""
+
+        class SourceA:
+            def __init__(self, name: str, a_extra: str):
+                self.name = name
+                self.a_extra = "from_a"
+
+        class SourceB:
+            def __init__(self, age: int, b_extra: str):
+                self.age = age
+                self.b_extra = "from_b"
+
+        class Target:
+            def __init__(self, name: str, age: int):
+                self.name = name
+                self.age = age
+
+        source_a = SourceA("Test", "from_a")
+        source_b = SourceB(30, "from_b")
+
+        # With map_missing_fields=True - both extra fields should be mapped
+        result = mapper.map(
+            (source_a, source_b), Target, skip_init=True, map_missing_fields=True
+        )
+
+        assert result.name == "Test"
+        assert result.age == 30
+        assert result.a_extra == "from_a"
+        assert result.b_extra == "from_b"
+
+        # Without map_missing_fields - extra fields should NOT be mapped
+        result_no_extra = mapper.map((source_a, source_b), Target, skip_init=True)
+
+        assert not hasattr(result_no_extra, "a_extra")
+        assert not hasattr(result_no_extra, "b_extra")
+
+    def test_map_missing_fields_with_exclusions_interaction(self, mapper):
+        """
+        IMPORTANT: Test interaction between map_missing_fields and exclusions.
+        This behavior is NOT clearly documented.
+        """
+
+        class Source:
+            def __init__(self, name: str, email: str, extra: str):
+                self.name = name
+                self.email = email
+                self.extra = "extra_value"
+
+        class Target:
+            def __init__(self, name: str, email: str):
+                self.name = name
+                self.email = email
+
+        source = Source("Test", "test@email.com", "extra")
+
+        mapper.add_mapping(source=Source, target=Target, exclusions={"email"})
+
+        # extra field should be mapped, email should be excluded
+        result = mapper.map(source, Target, skip_init=True, map_missing_fields=True)
+
+        assert result.name == "Test"
+        assert not hasattr(result, "email") or result.email is None
+        assert result.extra == "extra_value"
+
+    def test_pydantic_skip_init_with_map_missing_fields_bypasses_validation(
+        self, mapper
+    ):
+        """
+        IMPORTANT: Test that Pydantic validation is bypassed with skip_init.
+        This is NOT documented and can lead to invalid data.
+        """
+
+        class SourceModel(BaseModel):
+            name: str
+            age: int = -5  # Invalid age
+            extra: str = "extra"
+
+        class TargetModel(BaseModel):
+            model_config = {"extra": "allow"}
+            name: str
+            age: int
+
+            @field_validator("age")
+            def age_must_be_positive(cls, v):
+                if v < 0:
+                    raise ValueError("age must be positive")
+                return v
+
+        source = SourceModel(name="Test", age=-5)
+
+        # Should NOT raise during mapping with skip_init (construct bypasses validation)
+        with does_not_raise():
+            result = mapper.map(
+                source, TargetModel, skip_init=True, map_missing_fields=True
+            )
+            assert result.age == -5  # Invalid value is set
+            assert result.extra == "extra"
+
+        # But SHOULD raise when trying to validate the result
+        with pytest.raises(ValidationError):
+            TargetModel.model_validate(result.model_dump())
+
+    def test_map_missing_fields_false_is_default_behavior(self, mapper):
+        """
+        Verify that map_missing_fields=False is the DEFAULT behavior.
+        This is the breaking change from version 0.1.5-alpha.
+        """
+
+        class Source:
+            def __init__(self, name: str, extra: str):
+                self.name = name
+                self.extra = "extra_value"
+
+        class Target:
+            def __init__(self, name: str):
+                self.name = name
+
+        source = Source("Test", "extra_value")
+
+        # Default behavior (map_missing_fields not specified)
+        result_default = mapper.map(source, Target, skip_init=True)
+
+        # Explicit map_missing_fields=False
+        result_explicit_false = mapper.map(
+            source, Target, skip_init=True, map_missing_fields=False
+        )
+
+        # Both should behave the same - NOT mapping extra fields
+        assert result_default.name == "Test"
+        assert not hasattr(result_default, "extra")
+
+        assert result_explicit_false.name == "Test"
+        assert not hasattr(result_explicit_false, "extra")
+
+    def test_pydantic_without_extra_allow_and_map_missing_fields_true_raises_error(
+        self, mapper
+    ):
+        """
+        Verify that using map_missing_fields=True with Pydantic models
+        that DON'T have extra="allow" raises a clear error.
+        """
+
+        class SourceModel(BaseModel):
+            name: str
+            extra_field: str
+
+        class StrictTargetModel(BaseModel):
+            # No model_config with extra="allow"
+            name: str
+
+        source = SourceModel(name="Test", extra_field="extra")
+
+        # Should raise ValueError with clear message
+        with pytest.raises(
+            ValueError, match="Cannot map missing fields on target model"
+        ):
+            mapper.map(
+                source, StrictTargetModel, skip_init=True, map_missing_fields=True
+            )
+
+    def test_map_missing_fields_preserves_source_precedence_in_multiple_sources(
+        self, mapper
+    ):
+        """
+        Test that map_missing_fields respects source precedence when multiple sources
+        have the same extra field.
+        """
+
+        class SourceA:
+            def __init__(self, name: str):
+                self.name = name
+                self.shared_extra = "from_a"
+
+        class SourceB:
+            def __init__(self, age: int):
+                self.age = age
+                self.shared_extra = "from_b"
+
+        class Target:
+            def __init__(self, name: str, age: int):
+                self.name = name
+                self.age = age
+
+        source_a = SourceA("Test")
+        source_b = SourceB(30)
+
+        # SourceA comes first, so its shared_extra should win
+        result = mapper.map(
+            (source_a, source_b), Target, skip_init=True, map_missing_fields=True
+        )
+
+        assert result.shared_extra == "from_a"  # From first source
+
+    def test_map_missing_fields_with_none_values(self, mapper):
+        """
+        Test that map_missing_fields correctly handles None values in extra fields.
+        """
+
+        class Source:
+            def __init__(self, name: str, extra: Optional[str]):
+                self.name = name
+                self.extra = extra
+
+        class Target:
+            def __init__(self, name: str):
+                self.name = name
+
+        source = Source("Test", None)
+
+        result = mapper.map(source, Target, skip_init=True, map_missing_fields=True)
+
+        assert result.name == "Test"
+        assert hasattr(result, "extra")
+        assert result.extra is None

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -97,21 +97,24 @@ class TestBasicMapping:
         expected_name = reversed_string(source.name) if transform_name else source.name
         assert result.name == expected_name
 
-    def test_map_popo_to_popo_skip_init(self, mapper):
+    def test_map_popo_to_popo_skip_init_should_not_set_target_instance_attrs(
+        self, mapper
+    ):
         """Test mapping to a POPO target with skip_init=True."""
 
         # TODO Esse teste está quebrando pois como o skip_init é True, e o map_missing_fields é false, no momento de atribuir os valores da Source no Target
         # não é possível identificar que o value da Target existe, pois seu __init__ não foi executado. E isso é esperado
         class Source:
-            def __init__(self, value: str):
+            def __init__(self, value: str, class_field: str = "set"):
                 self.value = value
+                self.class_field = class_field
 
         class Target:
             def __init__(self, value: str = "default"):
                 self.value = value
                 self.initialized = True  # Mark if __init__ was called
 
-            extra_field: str = "not_set"
+            class_field: str = "not_set"
 
         source_instance = Source(value="test_value")
         mapper.add_mapping(source=Source, target=Target)
@@ -120,10 +123,11 @@ class TestBasicMapping:
         target_instance = mapper.map(source_instance, Target, skip_init=True)
 
         assert isinstance(target_instance, Target)
-        assert target_instance.value == "test_value"
+        assert not hasattr(target_instance, "value")
         assert not hasattr(
             target_instance, "initialized"
         )  # __init__ should not have been called
+        assert getattr(target_instance, "class_field") == "set"
 
     def test_map_without_add_mapping_dict_map_equal_attrs(self, mapper):
         """Test that calling map without adding a mapping dict maps everything that is equal to both source and target."""
@@ -147,7 +151,9 @@ class TestBasicMapping:
         assert isinstance(target, TargetModel)
         assert target.name == source_instance.name
 
-    def test_map_without_add_mapping_skip_init(self, mapper):
+    def test_map_without_add_mapping_skip_init_should_not_set_target_instance_attrs(
+        self, mapper
+    ):
         """Test mapping without add_mapping and with skip_init=True."""
 
         class SourceModel:
@@ -172,10 +178,10 @@ class TestBasicMapping:
         target = mapper.map(source_instance, target_instance_shell, skip_init=True)
 
         assert isinstance(target, TargetModel)
-        assert target.name == source_instance.name
-        assert target.age == source_instance.age  # Copied because skip_init=True
-        assert not hasattr(target, "job")  # Not in source, not set because of skip_init
-        assert target.extra_source_field == "source_only"
+        assert not hasattr(target, "name")
+        assert not hasattr(target, "age")
+        assert not hasattr(target, "job")
+        assert not hasattr(target, "extra_source_field")
 
     def test_map_without_add_mapping_multiple_sources(self, mapper):
         """Test mapping from multiple sources without add_mapping."""
@@ -214,7 +220,9 @@ class TestBasicMapping:
         assert target.city == source_b.city  # Takes from SourceModelB
         assert target.age == source_a.age  # Takes from SourceModelA
 
-    def test_map_without_add_mapping_multiple_sources_skip_init(self, mapper):
+    def test_map_without_add_mapping_multiple_sources_with_only_not_initialized_class_attrs_should_not_set_source_attrs(
+        self, mapper
+    ):
         """Test mapping from multiple sources without add_mapping and with skip_init=True."""
 
         class SourceModelA:
@@ -241,7 +249,48 @@ class TestBasicMapping:
         source_a = SourceModelA(name="Test", age=30)
         source_b = SourceModelB(job="Engineer", city="SF")
         target_instance_shell = object.__new__(TargetModel)
-        target = mapper.map((source_a, source_b), target_instance_shell, skip_init=True)
+        target = mapper.map((source_a, source_b), target_instance_shell)
+
+        assert isinstance(target, TargetModel)
+        assert not hasattr(target, "name")
+        assert not hasattr(target, "job")
+        assert not hasattr(target, "age")
+        assert not hasattr(target, "city")
+        assert not hasattr(target, "a_specific")
+        assert not hasattr(target, "b_specific")
+
+    def test_map_without_add_mapping_multiple_sources_with_only_not_initialized_class_attrs_should_set_source_attrs_when_flag_map_missing_fields_true(
+        self, mapper
+    ):
+        """Test mapping from multiple sources without add_mapping and with skip_init=True."""
+
+        class SourceModelA:
+            def __init__(self, name: str, age: int) -> None:
+                self.name = name
+                self.age = age
+                self.a_specific = "from_a"
+
+        class SourceModelB:
+            def __init__(self, job: str, city: str) -> None:
+                self.job = job
+                self.city = city
+                self.b_specific = "from_b"
+
+        class TargetModel:
+            name: str
+            age: int
+            job: str
+            city: str
+            a_specific: str
+            b_specific: str
+            # No __init__ for this test to ensure attributes are set directly
+
+        source_a = SourceModelA(name="Test", age=30)
+        source_b = SourceModelB(job="Engineer", city="SF")
+        target_instance_shell = object.__new__(TargetModel)
+        target = mapper.map(
+            (source_a, source_b), target_instance_shell, map_missing_fields=True
+        )
 
         assert isinstance(target, TargetModel)
         assert target.name == source_a.name
@@ -393,9 +442,11 @@ class TestErrorHandling:
 
         if should_raise:
             with pytest.raises(TypeError):
-                mapper.map(source, Target, skip_init=skip_init)
+                mapper.map(source, Target, skip_init=skip_init, map_missing_fields=True)
         else:
-            result = mapper.map(source, Target, skip_init=skip_init)
+            result = mapper.map(
+                source, Target, skip_init=skip_init, map_missing_fields=True
+            )
             assert result.email == source.email
 
     def test_add_mapping_source_attr_validation(self, mapper):
@@ -535,7 +586,9 @@ class TestAdvancedMapping:
                 source=Source, target=Target, mapping={"name": reversed_string}
             )
 
-    def test_mapping_from_source_instance(self, mapper, reversed_string):
+    def test_mapping_from_source_instance_should_not_set_attrs_that_not_has_been_initialized(
+        self, mapper, reversed_string
+    ):
         """
         Test adding a mapping using a source object instance instead of a class.
 
@@ -557,9 +610,37 @@ class TestAdvancedMapping:
         mapper.add_mapping(source=a, target=Target, mapping={"name": reversed_string})
         b = mapper.map(a, Target, skip_init=True)
         assert isinstance(b, Target)
+        assert not hasattr(b, "name")
+
+    def test_mapping_from_source_instance_with_flag_map_missing_fields(
+        self, mapper, reversed_string
+    ):
+        """
+        Test adding a mapping using a source object instance instead of a class.
+
+        Verifies that the mapper correctly handles instance-based mapping configurations
+        and applies transformations specified in the mapping dictionary.
+        """
+
+        class Source:
+            def __init__(self, name: str):
+                self.name = name
+
+        class Target:
+            def __init__(self, name: str, email: str):
+                self.name = name
+                self.email = email
+
+        a = Source("Johnny")
+
+        mapper.add_mapping(source=a, target=Target, mapping={"name": reversed_string})
+        b = mapper.map(a, Target, skip_init=True, map_missing_fields=True)
+        assert isinstance(b, Target)
         assert b.name == "ynnhoJ"
 
-    def test_mapping_from_multiple_source_instances(self, mapper, reversed_string):
+    def test_mapping_from_multiple_source_instances_should_not_set_attrs_that_not_has_been_initialized(
+        self, mapper, reversed_string
+    ):
         """
         Test adding a mapping using a tuple of source object instances.
 
@@ -589,6 +670,41 @@ class TestAdvancedMapping:
             source=(a, b), target=Target, mapping={"name": reversed_string}
         )
         c = mapper.map((a2, b), Target, skip_init=True)
+        assert isinstance(c, Target)
+        assert not hasattr(c, "name")
+
+    def test_mapping_from_multiple_source_instances_with_flag_map_missing_fields(
+        self, mapper, reversed_string
+    ):
+        """
+        Test adding a mapping using a tuple of source object instances.
+
+        Verifies that the mapper can handle multiple source objects and correctly
+        applies transformations when mapping from multiple sources.
+        """
+
+        class SourceA:
+            def __init__(self, name: str):
+                self.name = name
+
+        class SourceB:
+            def __init__(self, name: str, email: str):
+                self.name = name
+                self.email = email
+
+        class Target:
+            def __init__(self, name: str, email: str):
+                self.name = name
+                self.email = email
+
+        a = SourceA("Johnny")
+        a2 = SourceA("Johnny2")
+        b = SourceB(None, "johnny@email.com")
+
+        mapper.add_mapping(
+            source=(a, b), target=Target, mapping={"name": reversed_string}
+        )
+        c = mapper.map((a2, b), Target, skip_init=True, map_missing_fields=True)
         assert isinstance(c, Target)
         assert c.name == "2ynnhoJ"
 
@@ -1333,7 +1449,7 @@ class TestAdvancedMapping:
 
         class LargeSource:
             def __init__(self):
-                for i in range(1000):
+                for i in range(100000):
                     setattr(self, f"attr_{i}", i)
 
         class LargeTarget:
@@ -1345,11 +1461,12 @@ class TestAdvancedMapping:
         import time
 
         start = time.time()
-        result = mapper.map(source, LargeTarget, skip_init=True)
+        result = mapper.map(
+            source, LargeTarget, skip_init=True, map_missing_fields=True
+        )
         duration = time.time() - start
-
         assert duration < 1.0  # Should complete in under 1 second
-        assert all(getattr(result, f"attr_{i}") == i for i in range(1000))
+        assert all(getattr(result, f"attr_{i}") == i for i in range(100000))
 
     def test_mapping_with_none_extra(self, mapper):
         """Test that mapping works correctly when extra parameter is None."""
@@ -2479,11 +2596,11 @@ class TestMapMissingFieldsEdgeCases:
         source = Source("Test", "extra_value")
 
         # Default behavior (map_missing_fields not specified)
-        result_default = mapper.map(source, Target, skip_init=True)
+        result_default = mapper.map(source, Target, skip_init=False)
 
         # Explicit map_missing_fields=False
         result_explicit_false = mapper.map(
-            source, Target, skip_init=True, map_missing_fields=False
+            source, Target, skip_init=False, map_missing_fields=False
         )
 
         # Both should behave the same - NOT mapping extra fields


### PR DESCRIPTION
This pull request introduces enhanced support for mapping missing fields when mapping objects, particularly for Pydantic models, and refactors related methods for greater flexibility. The main changes involve adding a `map_missing_fields` parameter throughout the mapping logic, updating how attributes are set on target objects, and enforcing correct behavior for models that do not allow extra fields.

**Enhanced mapping flexibility and missing fields support:**

* Added a `map_missing_fields` parameter to the `map` method and propagated it through internal mapping logic, allowing callers to specify whether missing fields should be mapped to target objects. [[1]](diffhunk://#diff-6b2d0c89e5fef7f72d656ce0474c2068497681da370987b50c8f0992fdbe6862R298) [[2]](diffhunk://#diff-6b2d0c89e5fef7f72d656ce0474c2068497681da370987b50c8f0992fdbe6862R336) [[3]](diffhunk://#diff-6b2d0c89e5fef7f72d656ce0474c2068497681da370987b50c8f0992fdbe6862R398-L368)
* Updated `set_attrs` and `_initialize_target` methods in both the base adapter and `PydanticModelAdapter` to handle the `map_missing_fields` flag, including raising errors if the target Pydantic model does not allow extra fields. [[1]](diffhunk://#diff-6b2d0c89e5fef7f72d656ce0474c2068497681da370987b50c8f0992fdbe6862L121-R152) [[2]](diffhunk://#diff-6b2d0c89e5fef7f72d656ce0474c2068497681da370987b50c8f0992fdbe6862R214-R250) [[3]](diffhunk://#diff-6b2d0c89e5fef7f72d656ce0474c2068497681da370987b50c8f0992fdbe6862R398-L368)
* Refactored the internal `_build_target` logic to use the new `map_missing_fields` parameter and removed the old `_initialize_target` method from the main mapper class, delegating initialization to the adapter.